### PR TITLE
feat(visuals): add chromagram visual

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ pull request!
     - [x] Based on frequency
     - [x] Based on Loudness
     - [x] A single static color.
+- [x] **chromagram**
+  - [x] Displays the energy distribution across the 12 pitch classes of
+        Western music (C, C#, D, D#, E, F, F#, G, G#, A, A#, B),
+        accumulated across all audible octaves.
+  - [x] Each pitch class rendered in a distinct hue for instant visual
+        identification of tonal content.
+  - [x] Peak hold per pitch class with configurable decay.
+  - [x] Adjustable smoothing and noise floor.
+  - [x] Adjustable color map.
 
 ## Installation
 

--- a/src/domain/visuals.rs
+++ b/src/domain/visuals.rs
@@ -10,5 +10,6 @@ crate::macros::choice_enum!(no_default
         Spectrogram => "Spectrogram",
         Spectrum => "Spectrum",
         Stereometer => "Stereometer",
+        Chroma => "Chromagram",
     }
 );

--- a/src/persistence/settings.rs
+++ b/src/persistence/settings.rs
@@ -21,6 +21,6 @@ pub use store::SettingsHandle;
 pub(crate) use theme::canonical_theme_name;
 pub use theme::{BUILTIN_THEME, ThemeChoice, ThemeFile};
 pub use visuals::{
-    LoudnessSettings, ModuleSettings, OscilloscopeSettings, SpectrogramSettings, SpectrumSettings,
-    StereometerSettings, VisualSettings, WaveformSettings,
+    ChromaSettings, LoudnessSettings, ModuleSettings, OscilloscopeSettings, SpectrogramSettings,
+    SpectrumSettings, StereometerSettings, VisualSettings, WaveformSettings,
 };

--- a/src/persistence/settings/visuals.rs
+++ b/src/persistence/settings/visuals.rs
@@ -9,6 +9,7 @@ use crate::visuals::options::{
     SpectrumWeightingMode, StereometerMode, StereometerScale, WaveformColorMode,
 };
 use crate::visuals::{
+    chroma::processor::ChromaConfig,
     oscilloscope::processor::{OscilloscopeConfig, TriggerMode},
     spectrogram::processor::SpectrogramConfig,
     spectrum::processor::{AveragingMode, SpectrumConfig},
@@ -38,7 +39,8 @@ impl VisualSettings {
         }
         let valid = check!(Spectrogram => SpectrogramSettings, Spectrum => SpectrumSettings,
             Oscilloscope => OscilloscopeSettings, Waveform => WaveformSettings,
-            Loudness => LoudnessSettings, Stereometer => StereometerSettings);
+            Loudness => LoudnessSettings, Stereometer => StereometerSettings,
+            Chroma => ChromaSettings);
         self.modules.retain(valid);
         self.sanitize_layout();
     }
@@ -188,4 +190,11 @@ visual_settings!(StereometerSettings from StereometerConfig {
 visual_settings!(LoudnessSettings {
     left_mode: MeterMode = MeterMode::TruePeak,
     right_mode: MeterMode = MeterMode::LufsShortTerm,
+});
+
+visual_settings!(ChromaSettings from ChromaConfig {
+    fft_size: usize, hop_size: usize, min_freq_hz: f32, max_freq_hz: f32,
+    smoothing: f32, floor_db: f32, peak_decay: f32,
+} extra {
+    show_peak_hold: bool = true,
 });

--- a/src/ui/pages/visuals/settings.rs
+++ b/src/ui/pages/visuals/settings.rs
@@ -131,6 +131,7 @@ settings_modules! {
     spectrum => Spectrum,
     stereometer => Stereometer,
     waveform => Waveform,
+    chroma => Chroma,
 }
 
 pub trait ModuleSettingsPane: 'static {

--- a/src/ui/pages/visuals/settings/chroma.rs
+++ b/src/ui/pages/visuals/settings/chroma.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Maika Namuo
+
+use super::widgets::{SliderRange, set_if_changed, slide, toggle, update_f32_range};
+use crate::persistence::settings::ChromaSettings;
+use crate::visuals::chroma::processor::{
+    MAX_FLOOR_DB, MAX_SMOOTHING, MIN_FLOOR_DB, MIN_SMOOTHING,
+};
+use crate::visuals::registry::VisualKind;
+use iced::Element;
+
+settings_pane!(ChromaSettingsPane, ChromaSettings, VisualKind::Chroma, Chroma);
+
+const SMOOTHING_RANGE: SliderRange = SliderRange::new(MIN_SMOOTHING, MAX_SMOOTHING, 0.005);
+const FLOOR_RANGE: SliderRange = SliderRange::new(MIN_FLOOR_DB, MAX_FLOOR_DB, 1.0);
+
+settings_messages!(ChromaSettingsPane as pane, value {
+    Smoothing(f32) => update_f32_range(&mut pane.settings.smoothing, value, SMOOTHING_RANGE);
+    FloorDb(f32) => update_f32_range(&mut pane.settings.floor_db, value, FLOOR_RANGE);
+    ShowPeakHold(bool) => set_if_changed(&mut pane.settings.show_peak_hold, value);
+});
+
+impl ChromaSettingsPane {
+    fn view(&self) -> Element<'_, Message> {
+        let s = &self.settings;
+        controls!(16.0;
+            slider!(
+                "Smoothing",
+                s.smoothing,
+                SMOOTHING_RANGE,
+                Message::Smoothing,
+                format!("{:.3}", s.smoothing)
+            );
+            slider!(
+                "Floor",
+                s.floor_db,
+                FLOOR_RANGE,
+                Message::FloorDb,
+                format!("{:.0} dB", s.floor_db)
+            );
+            toggle("Peak hold", s.show_peak_hold, Message::ShowPeakHold);
+            super::palette_section(&self.palette, Message::Palette);
+        )
+        .into()
+    }
+}

--- a/src/visuals.rs
+++ b/src/visuals.rs
@@ -90,6 +90,7 @@ visual_modules! {
     spectrum { SpectrumProcessor, SpectrumConfig, SpectrumState },
     stereometer { StereometerProcessor, StereometerConfig, StereometerState },
     waveform { WaveformProcessor, WaveformConfig, WaveformState },
+    chroma { ChromaProcessor, ChromaConfig, ChromaState },
 }
 
 pub mod options;

--- a/src/visuals/chroma/processor.rs
+++ b/src/visuals/chroma/processor.rs
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Maika Namuo
+
+use crate::dsp::AudioBlock;
+use crate::util::audio::{DEFAULT_SAMPLE_RATE, WindowKind, apply_window, mixdown_into_deque, window_coefficients};
+use realfft::{RealFftPlanner, RealToComplex};
+use rustfft::num_complex::Complex32;
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+pub const NUM_PITCH_CLASSES: usize = 12;
+
+pub const NOTE_NAMES: [&str; NUM_PITCH_CLASSES] =
+    ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+
+// A4 = 440 Hz -> C0 = 440 * 2^(-69/12)
+const C0_HZ: f64 = 16.351_597_831_287_4;
+
+pub const DEFAULT_FFT_SIZE: usize = 4096;
+pub const DEFAULT_HOP_SIZE: usize = 1024;
+
+// full piano range, A0–C8
+pub const DEFAULT_MIN_FREQ_HZ: f32 = 27.5;
+pub const DEFAULT_MAX_FREQ_HZ: f32 = 4186.0;
+
+pub const MIN_SMOOTHING: f32 = 0.01;
+pub const MAX_SMOOTHING: f32 = 0.5;
+pub const MIN_FLOOR_DB: f32 = -100.0;
+pub const MAX_FLOOR_DB: f32 = -20.0;
+
+#[derive(Debug, Clone, Copy)]
+pub struct ChromaConfig {
+    pub sample_rate: f32,
+    pub fft_size: usize,
+    pub hop_size: usize,
+    pub min_freq_hz: f32,
+    pub max_freq_hz: f32,
+    /// 0 = slow, 1 = instant
+    pub smoothing: f32,
+    pub floor_db: f32,
+    /// < 1.0, applied every hop
+    pub peak_decay: f32,
+}
+
+impl Default for ChromaConfig {
+    fn default() -> Self {
+        Self {
+            sample_rate: DEFAULT_SAMPLE_RATE,
+            fft_size: DEFAULT_FFT_SIZE,
+            hop_size: DEFAULT_HOP_SIZE,
+            min_freq_hz: DEFAULT_MIN_FREQ_HZ,
+            max_freq_hz: DEFAULT_MAX_FREQ_HZ,
+            smoothing: 0.07,
+            floor_db: -80.0,
+            peak_decay: 0.998,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ChromaSnapshot {
+    pub bins: [f32; NUM_PITCH_CLASSES],
+    pub peak_bins: [f32; NUM_PITCH_CLASSES],
+}
+
+// hz -> 0..11 (C=0, B=11), None if <= 0 or non-finite
+fn freq_to_pitch_class(hz: f32) -> Option<usize> {
+    if hz <= 0.0 || !hz.is_finite() {
+        return None;
+    }
+    let p = 12.0 * (hz as f64 / C0_HZ).log2();
+    let pc = p.round().rem_euclid(12.0) as usize;
+    Some(pc)
+}
+
+pub struct ChromaProcessor {
+    config: ChromaConfig,
+    fft: Arc<dyn RealToComplex<f32>>,
+    fft_input: Vec<f32>,
+    fft_output: Vec<Complex32>,
+    scratch: Vec<Complex32>,
+    window: Arc<[f32]>,
+    mono_buf: VecDeque<f32>,
+    // bin -> pitch class, None if outside freq range
+    bin_class: Box<[Option<usize>]>,
+    smoothed_bins: [f32; NUM_PITCH_CLASSES],
+    peak_bins: [f32; NUM_PITCH_CLASSES],
+    snapshot: ChromaSnapshot,
+}
+
+impl ChromaProcessor {
+    pub fn new(config: ChromaConfig) -> Self {
+        let fft_size = config.fft_size.next_power_of_two().max(64);
+        let fft = RealFftPlanner::new().plan_fft_forward(fft_size);
+        let window = window_coefficients(WindowKind::Hann, fft_size);
+        let bin_class = Self::precompute_bin_classes(
+            fft_size,
+            config.sample_rate,
+            config.min_freq_hz,
+            config.max_freq_hz,
+        );
+        let fft_input = fft.make_input_vec();
+        let fft_output = fft.make_output_vec();
+        let scratch = fft.make_scratch_vec();
+        Self {
+            config,
+            fft,
+            fft_input,
+            fft_output,
+            scratch,
+            window,
+            mono_buf: VecDeque::new(),
+            bin_class,
+            smoothed_bins: [0.0; NUM_PITCH_CLASSES],
+            peak_bins: [0.0; NUM_PITCH_CLASSES],
+            snapshot: ChromaSnapshot::default(),
+        }
+    }
+
+    pub fn config(&self) -> ChromaConfig {
+        self.config
+    }
+
+    pub fn update_config(&mut self, config: ChromaConfig) {
+        let rebuild = config.fft_size != self.config.fft_size
+            || (config.sample_rate - self.config.sample_rate).abs() > f32::EPSILON
+            || (config.min_freq_hz - self.config.min_freq_hz).abs() > 0.01
+            || (config.max_freq_hz - self.config.max_freq_hz).abs() > 0.01;
+        self.config = config;
+        if rebuild {
+            self.rebuild();
+        }
+    }
+
+    fn rebuild(&mut self) {
+        let fft_size = self.config.fft_size.next_power_of_two().max(64);
+        let fft = RealFftPlanner::new().plan_fft_forward(fft_size);
+        self.window = window_coefficients(WindowKind::Hann, fft_size);
+        self.bin_class = Self::precompute_bin_classes(
+            fft_size,
+            self.config.sample_rate,
+            self.config.min_freq_hz,
+            self.config.max_freq_hz,
+        );
+        self.fft_input = fft.make_input_vec();
+        self.fft_output = fft.make_output_vec();
+        self.scratch = fft.make_scratch_vec();
+        self.fft = fft;
+        self.mono_buf.clear();
+        self.smoothed_bins = [0.0; NUM_PITCH_CLASSES];
+        self.peak_bins = [0.0; NUM_PITCH_CLASSES];
+    }
+
+    fn precompute_bin_classes(
+        fft_size: usize,
+        sample_rate: f32,
+        min_freq: f32,
+        max_freq: f32,
+    ) -> Box<[Option<usize>]> {
+        let spectrum_len = fft_size / 2 + 1;
+        let bin_hz = sample_rate / fft_size as f32;
+        (0..spectrum_len)
+            .map(|b| {
+                let hz = b as f32 * bin_hz;
+                if hz < min_freq || hz > max_freq {
+                    return None;
+                }
+                freq_to_pitch_class(hz)
+            })
+            .collect()
+    }
+
+    pub fn process_block(&mut self, block: &AudioBlock<'_>) -> Option<ChromaSnapshot> {
+        if block.frame_count() == 0 {
+            return None;
+        }
+
+        let sample_rate = block.sample_rate.max(1.0);
+        if (sample_rate - self.config.sample_rate).abs() > f32::EPSILON {
+            self.config.sample_rate = sample_rate;
+            self.rebuild();
+        }
+
+        mixdown_into_deque(&mut self.mono_buf, block.samples, block.channels.max(1));
+
+        let fft_size = self.config.fft_size.next_power_of_two().max(64);
+        let hop_size = self.config.hop_size.clamp(1, fft_size);
+        let mut any = false;
+
+        while self.mono_buf.len() >= fft_size {
+            self.fill_and_window(fft_size);
+            if self
+                .fft
+                .process_with_scratch(
+                    &mut self.fft_input,
+                    &mut self.fft_output,
+                    &mut self.scratch,
+                )
+                .is_ok()
+            {
+                self.accumulate_spectrum(fft_size);
+            }
+            self.mono_buf.drain(..hop_size);
+            any = true;
+        }
+
+        if any {
+            self.snapshot.bins = self.smoothed_bins;
+            self.snapshot.peak_bins = self.peak_bins;
+        }
+        Some(self.snapshot)
+    }
+
+    fn fill_and_window(&mut self, fft_size: usize) {
+        let window = self.window.clone();
+        for (i, s) in self.mono_buf.iter().take(fft_size).enumerate() {
+            self.fft_input[i] = *s;
+        }
+        apply_window(&mut self.fft_input[..fft_size], &window);
+    }
+
+    fn accumulate_spectrum(&mut self, fft_size: usize) {
+        let floor_power = 10.0_f32.powf(self.config.floor_db / 10.0);
+        let scale = 1.0 / (fft_size as f32 * fft_size as f32);
+
+        let mut raw = [0.0_f32; NUM_PITCH_CLASSES];
+        let mut count = [0_u32; NUM_PITCH_CLASSES];
+
+        for (b, &pc_opt) in self.bin_class.iter().enumerate() {
+            let Some(pc) = pc_opt else { continue };
+            let power = self.fft_output[b].norm_sqr() * scale;
+            raw[pc] += power;
+            count[pc] += 1;
+        }
+
+        // avg power per class
+        for i in 0..NUM_PITCH_CLASSES {
+            if count[i] > 0 {
+                raw[i] /= count[i] as f32;
+            }
+        }
+
+        // normalize to loudest, floor at floor_power
+        let peak_raw = raw.iter().cloned().fold(floor_power, f32::max);
+        let normalized: [f32; NUM_PITCH_CLASSES] =
+            std::array::from_fn(|i| (raw[i] / peak_raw).clamp(0.0, 1.0).sqrt());
+
+        let alpha = self.config.smoothing.clamp(MIN_SMOOTHING, MAX_SMOOTHING);
+        let decay = self.config.peak_decay.clamp(0.9, 1.0);
+
+        for ((smoothed, peak), norm) in self
+            .smoothed_bins
+            .iter_mut()
+            .zip(self.peak_bins.iter_mut())
+            .zip(normalized.iter())
+        {
+            *smoothed += alpha * (norm - *smoothed);
+            *peak = (*peak * decay).max(*smoothed);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RATE: f32 = 48_000.0;
+
+    fn block(samples: &[f32], channels: usize) -> AudioBlock<'_> {
+        AudioBlock::now(samples, channels, RATE)
+    }
+
+    #[test]
+    fn pitch_class_mapping() {
+        assert_eq!(freq_to_pitch_class(261.63), Some(0)); // C4 -> C
+        assert_eq!(freq_to_pitch_class(440.0), Some(9));  // A4 -> A
+        assert_eq!(freq_to_pitch_class(659.26), Some(4)); // E5 -> E
+    }
+
+    #[test]
+    fn process_sine_wave_returns_snapshot() {
+        let mut proc = ChromaProcessor::new(ChromaConfig::default());
+        let samples: Vec<f32> = (0..DEFAULT_FFT_SIZE * 2)
+            .map(|n| (2.0 * std::f32::consts::PI * 440.0 * n as f32 / RATE).sin())
+            .collect();
+        let snap = proc.process_block(&block(&samples, 1));
+        assert!(snap.is_some());
+    }
+
+    #[test]
+    fn a440_activates_a_pitch_class() {
+        let mut proc = ChromaProcessor::new(ChromaConfig {
+            smoothing: 1.0,
+            ..Default::default()
+        });
+        let n_samples = DEFAULT_FFT_SIZE * 4;
+        let samples: Vec<f32> = (0..n_samples)
+            .map(|n| (2.0 * std::f32::consts::PI * 440.0 * n as f32 / RATE).sin())
+            .collect();
+        let snap = proc.process_block(&block(&samples, 1)).unwrap();
+        // A => class 9, should win
+        let a_class = snap.bins[9];
+        let max_other = snap
+            .bins
+            .iter()
+            .enumerate()
+            .filter(|&(i, _)| i != 9)
+            .map(|(_, &v)| v)
+            .fold(0.0_f32, f32::max);
+        assert!(
+            a_class > max_other,
+            "A class ({a_class:.3}) should dominate other classes (max {max_other:.3})"
+        );
+    }
+}

--- a/src/visuals/chroma/render.rs
+++ b/src/visuals/chroma/render.rs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Maika Namuo
+
+use crate::visuals::render::common::{
+    ClipTransform, SdfVertex, gradient_quad_vertices, line_vertices, sdf_primitive,
+};
+use iced::Rectangle;
+use iced::advanced::graphics::Viewport;
+
+use super::processor::NUM_PITCH_CLASSES;
+
+const BAR_GAP_FRACTION: f32 = 0.12;
+const PEAK_MARKER_THICKNESS: f32 = 1.5;
+pub const VERTICAL_PADDING: f32 = 6.0;
+pub const LABEL_AREA_HEIGHT: f32 = 16.0;
+
+#[derive(Debug, Clone)]
+pub struct ChromaParams {
+    pub bounds: Rectangle,
+    pub bins: [f32; NUM_PITCH_CLASSES],
+    pub peak_bins: Option<[f32; NUM_PITCH_CLASSES]>,
+    pub note_colors: [[f32; 4]; NUM_PITCH_CLASSES],
+    pub peak_color: [f32; 4],
+    pub note_names: [&'static str; NUM_PITCH_CLASSES],
+    pub key: u64,
+}
+
+#[derive(Debug)]
+pub struct ChromaPrimitive {
+    params: ChromaParams,
+}
+
+impl ChromaPrimitive {
+    pub fn new(params: ChromaParams) -> Self {
+        Self { params }
+    }
+
+    fn build_vertices(&self, viewport: &Viewport) -> Vec<SdfVertex> {
+        let clip = ClipTransform::from_viewport(viewport);
+        let bounds = self.params.bounds;
+
+        let usable_h = (bounds.height - VERTICAL_PADDING * 2.0 - LABEL_AREA_HEIGHT).max(0.0);
+        let usable_w = bounds.width;
+
+        if usable_h <= 0.0 || usable_w <= 0.0 {
+            return Vec::new();
+        }
+
+        let bar_slot = usable_w / NUM_PITCH_CLASSES as f32;
+        let gap = bar_slot * BAR_GAP_FRACTION;
+        let bar_w = (bar_slot - gap).max(1.0);
+
+        let top_y = bounds.y + VERTICAL_PADDING;
+        let bottom_y = top_y + usable_h;
+
+        let mut verts = Vec::with_capacity(NUM_PITCH_CLASSES * 18);
+
+        for i in 0..NUM_PITCH_CLASSES {
+            let x0 = bounds.x + i as f32 * bar_slot + gap * 0.5;
+            let x1 = x0 + bar_w;
+            let color = self.params.note_colors[i];
+            let level = self.params.bins[i].clamp(0.0, 1.0);
+
+            let bar_top = bottom_y - usable_h * level;
+
+            let transparent = [color[0], color[1], color[2], 0.0];
+            verts.extend(gradient_quad_vertices(
+                x0, bar_top, x1, bottom_y, clip, color, transparent,
+            ));
+
+            if let Some(peaks) = self.params.peak_bins {
+                let peak = peaks[i].clamp(0.0, 1.0);
+                if peak > 0.01 {
+                    let peak_y = bottom_y - usable_h * peak;
+                    verts.extend(line_vertices(
+                        (x0, peak_y),
+                        (x1, peak_y),
+                        self.params.peak_color,
+                        self.params.peak_color,
+                        PEAK_MARKER_THICKNESS,
+                        clip,
+                    ));
+                }
+            }
+        }
+
+        verts
+    }
+}
+
+sdf_primitive!(
+    ChromaPrimitive,
+    Pipeline,
+    u64,
+    "Chroma",
+    TriangleList,
+    |self| self.params.key
+);

--- a/src/visuals/chroma/state.rs
+++ b/src/visuals/chroma/state.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Maika Namuo
+
+use super::processor::{ChromaSnapshot, NOTE_NAMES, NUM_PITCH_CLASSES};
+use super::render::{ChromaParams, ChromaPrimitive, LABEL_AREA_HEIGHT, VERTICAL_PADDING};
+use crate::util::color::color_to_rgba;
+use crate::visuals::palettes;
+use crate::visuals::render::common::{fill_rect, make_text};
+use iced::advanced::text;
+use iced::alignment::{Horizontal, Vertical};
+use iced::{Color, Point, Rectangle, Size};
+
+pub(crate) const CHROMA_PALETTE_SIZE: usize = palettes::chroma::COLORS.len();
+
+const LABEL_FONT_SIZE: f32 = 10.0;
+
+#[derive(Debug, Clone)]
+pub(crate) struct ChromaState {
+    snapshot: ChromaSnapshot,
+    pub(crate) palette: [Color; CHROMA_PALETTE_SIZE],
+    pub(crate) show_peak_hold: bool,
+    key: u64,
+}
+
+impl ChromaState {
+    pub fn new() -> Self {
+        Self {
+            snapshot: ChromaSnapshot::default(),
+            palette: palettes::chroma::COLORS,
+            show_peak_hold: true,
+            key: crate::visuals::next_key(),
+        }
+    }
+
+    pub fn apply_snapshot(&mut self, snapshot: ChromaSnapshot) {
+        self.snapshot = snapshot;
+    }
+
+    pub fn set_palette(&mut self, palette: &[Color; CHROMA_PALETTE_SIZE]) {
+        self.palette = *palette;
+    }
+
+    pub(crate) fn visual_params(&self, bounds: Rectangle) -> Option<ChromaParams> {
+        if bounds.width <= 0.0 || bounds.height <= 0.0 {
+            return None;
+        }
+
+        let note_colors: [[f32; 4]; NUM_PITCH_CLASSES] =
+            std::array::from_fn(|i| color_to_rgba(self.palette[i]));
+        let peak_color = color_to_rgba(self.palette[CHROMA_PALETTE_SIZE - 1]);
+
+        Some(ChromaParams {
+            bounds,
+            bins: self.snapshot.bins,
+            peak_bins: if self.show_peak_hold {
+                Some(self.snapshot.peak_bins)
+            } else {
+                None
+            },
+            note_colors,
+            peak_color,
+            note_names: NOTE_NAMES,
+            key: self.key,
+        })
+    }
+}
+
+crate::visuals::visualization_widget!(
+    Chroma, ChromaState,
+    |this, renderer, theme, bounds| {
+        let state = this.state.borrow();
+        let bg = theme.extended_palette().background.base.color;
+
+        let Some(params) = state.visual_params(bounds) else {
+            fill_rect(renderer, bounds, bg);
+            return;
+        };
+
+        renderer.draw_primitive(bounds, ChromaPrimitive::new(params.clone()));
+
+        // note names along the bottom
+        let usable_h = (bounds.height - VERTICAL_PADDING * 2.0 - LABEL_AREA_HEIGHT).max(0.0);
+        let bar_slot = bounds.width / NUM_PITCH_CLASSES as f32;
+        let label_y = bounds.y + VERTICAL_PADDING + usable_h;
+
+        for (i, &name) in params.note_names.iter().enumerate() {
+            let cx = bounds.x + (i as f32 + 0.5) * bar_slot;
+            let color = state.palette[i];
+            let mut t = make_text(name, LABEL_FONT_SIZE, Size::new(bar_slot, LABEL_AREA_HEIGHT));
+            t.align_x = Horizontal::Center.into();
+            t.align_y = Vertical::Center;
+            text::Renderer::fill_text(
+                renderer,
+                t,
+                Point::new(cx, label_y + LABEL_AREA_HEIGHT * 0.5),
+                color,
+                bounds,
+            );
+        }
+    }
+);

--- a/src/visuals/palettes.rs
+++ b/src/visuals/palettes.rs
@@ -73,6 +73,7 @@ impl Palette {
             VisualKind::Oscilloscope => p!(oscilloscope),
             VisualKind::Stereometer => p!(stereometer),
             VisualKind::Loudness => p!(loudness),
+            VisualKind::Chroma => p!(chroma),
         }
     }
 }
@@ -205,4 +206,42 @@ pub mod background {
     pub const COLORS: [Color; 1] = [BG_BASE];
     pub const LABELS: &[&str] = &["Background"];
     pub const DEFAULT_POSITIONS: [f32; COLORS.len()] = [0.0];
+}
+
+// Chromagram: 12 pitch-class colors (C–B) + 1 peak-hold color
+pub mod chroma {
+    use super::{Color, hex};
+    pub const COLORS: [Color; 13] = [
+        hex(0xFF, 0x30, 0x30, 0xFF), // C  – red
+        hex(0xFF, 0x70, 0x10, 0xFF), // C# – red-orange
+        hex(0xFF, 0xA8, 0x00, 0xFF), // D  – orange
+        hex(0xD4, 0xD4, 0x00, 0xFF), // D# – yellow
+        hex(0x80, 0xFF, 0x00, 0xFF), // E  – yellow-green
+        hex(0x00, 0xFF, 0x50, 0xFF), // F  – green
+        hex(0x00, 0xFF, 0xC0, 0xFF), // F# – cyan-green
+        hex(0x00, 0xC0, 0xFF, 0xFF), // G  – sky blue
+        hex(0x00, 0x60, 0xFF, 0xFF), // G# – blue
+        hex(0x80, 0x00, 0xFF, 0xFF), // A  – violet
+        hex(0xC0, 0x00, 0xFF, 0xFF), // A# – purple
+        hex(0xFF, 0x00, 0x90, 0xFF), // B  – magenta
+        hex(0xFF, 0xFF, 0xFF, 0xFF), // Peak hold marker
+    ];
+    pub const LABELS: &[&str] = &[
+        "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B", "Peak",
+    ];
+    pub const DEFAULT_POSITIONS: [f32; COLORS.len()] = [
+        0.0,
+        1.0 / 12.0,
+        2.0 / 12.0,
+        3.0 / 12.0,
+        4.0 / 12.0,
+        5.0 / 12.0,
+        6.0 / 12.0,
+        7.0 / 12.0,
+        8.0 / 12.0,
+        9.0 / 12.0,
+        10.0 / 12.0,
+        11.0 / 12.0,
+        1.0,
+    ];
 }

--- a/src/visuals/registry.rs
+++ b/src/visuals/registry.rs
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Maika Namuo
 
 use super::{
-    loudness,
+    chroma, loudness,
     options::StereometerMode,
     oscilloscope, palettes,
     spectrogram::{self, processor::MAX_SPECTROGRAM_HISTORY_COLUMNS},
@@ -231,6 +231,23 @@ visuals! {
             out.target_sample_count = cfg.target_sample_count;
             out.correlation_window = cfg.correlation_window;
             out.palette = visuals!(@export_palette &st.palette, &palettes::stereometer::COLORS); out };
+
+    Chroma("Chromagram", 300.0, 180.0, 220.0) =>
+        chroma::ChromaProcessor, ChromaConfig, ChromaState;
+        settings_cfg::ChromaSettings;
+        apply(p, s, set) {
+            visuals!(@apply_config p, set);
+            let mut st = s.borrow_mut();
+            st.show_peak_hold = set.show_peak_hold;
+            visuals!(@apply_palette st, set, &palettes::chroma::COLORS);
+        };
+        export(p, s) {
+            let st = s.borrow();
+            let mut out = settings_cfg::ChromaSettings::from_config(&p.config());
+            out.show_peak_hold = st.show_peak_hold;
+            out.palette = visuals!(@export_palette &st.palette, &palettes::chroma::COLORS);
+            out
+        };
 }
 
 struct Visual<P, S> {


### PR DESCRIPTION
saved me a couple of bucks for MiniMeters, so I figured I would give back (this is a feature that is particularly useful for musicians looking at say, dominant chord notes, etc)

## what it does

chromagram → shows energy across the 12 pitch classes of western music (C, C#, D … B), folded from all audible octaves into a single bar chart. lets you see at a glance what tonal content is dominant in a mix without needing to read a spectrogram.

## implementation

follows the existing \`processor / state / render\` pattern:

- \`processor.rs\` → 4096-pt Hann FFT, maps each bin to a pitch class via \`freq → 12·log₂(freq/C₀) mod 12\`, EMA smoothing + peak hold with configurable decay
- \`render.rs\` → gradient quads + peak marker lines via \`sdf_primitive!\`
- \`state.rs\` → \`visualization_widget!\` closure form to draw iced text labels (note names) on top of the wgpu primitive
- settings panel: smoothing, noise floor, peak hold toggle, custom palette
- 3 unit tests: pitch class mapping math, snapshot production, A440 → A class

wired into \`domain\`, \`registry\`, \`palettes\`, \`persistence\`, and settings UI following the same steps as the other visuals.

\`cargo clippy\` passes clean.