### PR TITLE
fix: `float-literal-f32-fallback` fcw, `useless_borrows_in_formatting` clippy warning

### DIFF
--- a/src/ui/config.rs
+++ b/src/ui/config.rs
@@ -340,7 +340,7 @@ impl ConfigPage {
 
     fn build_device_choices(&self, snapshot: &RegistrySnapshot) -> Vec<DeviceOption> {
         let mut choices = vec![DeviceOption {
-            label: format!("Default sink - {}", &self.hardware_sink_label),
+            label: format!("Default sink - {}", self.hardware_sink_label),
             selection: DeviceSelection::Default,
         }];
         let mut devices: Vec<_> = snapshot

--- a/src/ui/widgets/palette_editor.rs
+++ b/src/ui/widgets/palette_editor.rs
@@ -557,7 +557,7 @@ fn channel_slider<'a>(
                 }
                 PaletteEvent::Adjust { index, color: nc }
             })
-            .step(0.01)
+            .step(0.01f32)
             .style(ui_theme::slider_style)
             .width(Length::Fill),
         )


### PR DESCRIPTION
## Summary

Fixes a future-compatibility warning emitted when compiling with newer compiler versions (https://github.com/rust-lang/rust/issues/154024) and a clippy warning emitted by newer versions of clippy. Contains no user-visible behavior changes.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] Commits include a `Signed-off-by:` footer.
- [x] I added or updated tests, or explained why not.
- [x] I updated documentation when user-visible behavior changed.
- [x] If AI tools were used, I reviewed the result carefully.
